### PR TITLE
Flamegraph-based optimizations

### DIFF
--- a/cmd/enigma-cracker/main.go
+++ b/cmd/enigma-cracker/main.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime/pprof"
 	"sort"
 	"sync"
 	"time"
@@ -46,9 +47,9 @@ func decodeRotorConfig(rotorModels []string, message string) (map[string]float64
 		for r2 := 0; r2 < 26; r2++ {
 			for r3 := 0; r3 < 26; r3++ {
 				rotorConfig := []enigma.RotorConfig{
-					{rotorModels[0], 'A' + r1, 0},
-					{rotorModels[1], 'A' + r2, 0},
-					{rotorModels[2], 'A' + r3, 0},
+					{Model: rotorModels[0], Position: 'A' + r1, Offset: 0},
+					{Model: rotorModels[1], Position: 'A' + r2, Offset: 0},
+					{Model: rotorModels[2], Position: 'A' + r3, Offset: 0},
 				}
 				machineConfig := enigma.MachineConfig{
 					RotorConfig:       rotorConfig,
@@ -76,6 +77,14 @@ func decodeRotorConfig(rotorModels []string, message string) (map[string]float64
 // tries to guess the Enigma configuration and decode passed text
 func decode(message string) {
 	start := time.Now()
+
+	f, err := os.Create("profile.prof")
+	if err != nil {
+		panic(err)
+	}
+	pprof.StartCPUProfile(f)
+	defer pprof.StopCPUProfile()
+
 	message = enigma.PreprocessText(message)
 	rotorModels := enigma.AvailableRotorModels()
 
@@ -116,7 +125,7 @@ func decode(message string) {
 	}
 
 	printResult(scores, 10)
-	fmt.Printf("Elapsed time %s", time.Since(start))
+	fmt.Printf("Elapsed time %s\n", time.Since(start))
 }
 
 // Go is a statically typed, compiled programming language designed at Google by Robert Griesemer, Rob Pike, and Ken Thompson.

--- a/pkg/enigma/machine.go
+++ b/pkg/enigma/machine.go
@@ -101,12 +101,13 @@ func (machine *Machine) passChar(character byte) byte {
 }
 
 func (machine *Machine) PassString(message string) string {
-	var result string
+	var b strings.Builder
+	b.Grow(len(message))
 	for _, character := range message {
 		encodedCharacter := machine.passChar(byte(character))
-		result += string(encodedCharacter)
+		b.WriteByte(encodedCharacter)
 	}
-	return result
+	return b.String()
 }
 
 // NewMachine creates a new Enigma machine.

--- a/pkg/enigma/rotors.go
+++ b/pkg/enigma/rotors.go
@@ -16,6 +16,17 @@ var rotorMappings = map[string]string{
 	"VIII": "FKQHTLXOCBJSPDZRAMEWNIUYGV",
 }
 
+var rotorBackMappings = map[string]string{
+	"I":    "UWYGADFPVZBECKMTHXSLRINQOJ",
+	"II":   "AJPCZWRLFBDKOTYUQGENHXMIVS",
+	"III":  "TAGBPCSDQEUFVNZHYIXJWLRKOM",
+	"IV":   "HZWVARTNLGUPXQCEJMBSKDYOIF",
+	"V":    "QCYLXWENFTZOSMVJUDKGIARPHB",
+	"VI":   "SKXQLHCNWARVGMEBJPTYFDZUIO",
+	"VII":  "QMGYVPEDRCWTIANUXFKZOSLHJB",
+	"VIII": "QJINSAYDVKBFRUHMCPLEWZTGXO",
+}
+
 var rotorNotchPositions = map[string][]byte{
 	"I":    {'Q'},
 	"II":   {'E'},
@@ -113,15 +124,9 @@ func NewRotor(model string, position, offset int) (Rotor, error) {
 		return Rotor{}, fmt.Errorf("mapping not found for rotor model %s", model)
 	}
 
-	// forms a back mapping for the back pass
-	var backMapping string
-	alphabet := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	for _, letter := range alphabet {
-		for j, letterInMapping := range mapping {
-			if letter == letterInMapping {
-				backMapping += string(alphabet[j])
-			}
-		}
+	backMapping, ok := rotorBackMappings[model]
+	if !ok {
+		return Rotor{}, fmt.Errorf("backwards mapping not found for rotor model %s", model)
 	}
 
 	notchPositions, ok := rotorNotchPositions[model]

--- a/pkg/enigma/rotors.go
+++ b/pkg/enigma/rotors.go
@@ -16,15 +16,15 @@ var rotorMappings = map[string]string{
 	"VIII": "FKQHTLXOCBJSPDZRAMEWNIUYGV",
 }
 
-var rotorNotchPositions = map[string][]string{
-	"I":    {"Q"},
-	"II":   {"E"},
-	"III":  {"V"},
-	"IV":   {"J"},
-	"V":    {"Z"},
-	"VI":   {"Z", "M"},
-	"VII":  {"Z", "M"},
-	"VIII": {"Z", "M"},
+var rotorNotchPositions = map[string][]byte{
+	"I":    {'Q'},
+	"II":   {'E'},
+	"III":  {'V'},
+	"IV":   {'J'},
+	"V":    {'Z'},
+	"VI":   {'Z', 'M'},
+	"VII":  {'Z', 'M'},
+	"VIII": {'Z', 'M'},
 }
 
 func AvailableRotorModels() []string {
@@ -45,7 +45,7 @@ type Rotor struct {
 	backMapping    string
 	position       int
 	offset         int
-	notchPositions []string
+	notchPositions []byte
 }
 
 func (rotor *Rotor) passCharacter(mapping string, character byte) byte {
@@ -83,7 +83,7 @@ func (rotor *Rotor) Spin() {
 }
 
 func (rotor *Rotor) IsAtNotch() bool {
-	var currentPosition = fmt.Sprintf("%c", rotor.position+'A')
+	var currentPosition = byte(rotor.position + 'A')
 	for _, position := range rotor.notchPositions {
 		if position == currentPosition {
 			return true


### PR DESCRIPTION
Reduce allocations, don't compute on the fly something that can be computed once beforehand. Overall speedup is from ~25 seconds to ~9 seconds for bruteforcing an Enigma config

Baseline:

![00_before](https://github.com/user-attachments/assets/8995b2e2-984e-46f7-8ac1-051c06656baf)

Use char instead of string in notch detection (reduce allocations):

![01_notch_char](https://github.com/user-attachments/assets/27abcfd7-c51a-4c73-9fe0-36f843268f69)

Precompute backwards mappings for each rotor instead of computing them each time on the fly:

![02_const_backmapping](https://github.com/user-attachments/assets/be284d67-179e-4eec-b7d0-93270d6303f3)

Use `string.Builder` instead of appending to a string directly when creating a result

![03_stringbuilder](https://github.com/user-attachments/assets/18330070-77d1-4d32-929a-70a4304a8289)

